### PR TITLE
[1주차] 버블정렬 1838

### DIFF
--- a/이다은/week-1-1838.js
+++ b/이다은/week-1-1838.js
@@ -1,38 +1,32 @@
 /**
  * 1주차 - 정렬
- * 해당 코드는 시간 초과로 틀렸습니다.
- * 이중 for문이 아닌 다른 정렬 방법을 찾아야 합니다.
- * 코드 추후 수정 예정
+ * 코드 수정하였습니다.
  */
 const fs = require('fs');
 const input = `5
 30 10 44 27 49`.trim().split('\n');
 //디버깅을 위해 input값 수정, 백준에는 아래 코드 사용
-//fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+//fs.readFileSync('/dev/stdin').toString().trim().split(/\s+/).map(Number);
 
-const N = Number(input[0]);
-const A = input[1].split(' ').map(Number);
+const N = Number(input[0]); 
+const A = input[1].split(' ').map(Number); 
 
 //const sorted = [...A].sort((a, b) => a - b);
 
-function solution(N, A) {
-  let ans = 0;
-  for (let i = 0; i < N; i++ ) {
-    let flag = 0;
-    for (let j = 0; j < N - 1; j++ ) {
-        if (A[j] > A[j + 1]) {
-            flag = 1;
-            temp = A[j];
-            A[j] = A[j + 1];
-            A[j + 1] = temp;
-        }
-    }
-    if (flag === 0) {
-      ans = i;
-      break;
-    }
+const arr = A.map((value, index) => ({ value, index }));
+// 입력을 valeu + index로 묶기
+arr.sort((a, b) => a.value - b.value);
+// value 기준으로 정렬, 버블 정렬과 똑같은 오름차순 상태로 정렬
+
+let maxShift = 0;
+
+for (let i = 0; i < N; i++) {
+  const shift = arr[i].index - i;
+  //이 값이 원래보다 얼마나 뒤에 있었는지, 즉 몇 칸 앞으로 왔는지 계산
+  if (shift > maxShift) {
+    maxShift = shift;
   }
-console.log(ans);
 }
 
-solution(N, A);
+console.log(maxShift);
+//정렬이 끝났을 때의 i 값


### PR DESCRIPTION
### 📘 문제 설명

- 문제 링크: [백준 1838번](https://www.acmicpc.net/problem/1838)
- 버블 정렬을 개선한 코드에서 정렬이 완료되는 시점의 `i` 값을 구하는 문제입니다.
- 개선된 버블 정렬은 flag 변수를 통해 더 이상 swap이 일어나지 않으면 정렬을 조기 종료합니다.

---

### 💡 풀이 요약

- 실제 버블 정렬을 수행하면 시간 복잡도 O(N²)로 시간 초과가 발생
- 실제 정렬은 수행하지 않고, 정렬 후 각 숫자가 원래 위치에서 얼마나 이동했는지를 이용하여 종료 시점을 추정 (@yo-ong 동현님 코드 참고)

---

### 🤔 회고
- 처음엔 버블 정렬이 한 번의 루프마다 하나씩만 자리를 옮기니까 <이동 거리 + 1>을 해야 정렬이 끝난다고 생각했는데, 실제로 몇번 정렬이 돌았는 지가 아니라 정렬이 완료되었을 때의 변수 i를 출력해야 해서 +1을 할 필요가 없었습니다~!
