### PR TITLE
[BOJ 2512] 예산

### DIFF
--- a/이유섭/2512.js
+++ b/이유섭/2512.js
@@ -1,0 +1,43 @@
+const fs = require("fs");
+const input = fs.readFileSync("/dev/stdin").toString().trim().split("\n");
+
+const requestedBudgets = input[1].split(" ").map(Number);
+const totalBudget = Number(input[2]);
+
+// 요청 총합 계산
+const totalRequested = requestedBudgets.reduce(
+  (sum, budget) => sum + budget,
+  0
+);
+
+// 요청 총합이 전체 예산 이하라면 최대 요청값 출력
+if (totalRequested <= totalBudget) {
+  console.log(Math.max(...requestedBudgets));
+} else {
+  // 이진 탐색으로 상한액 찾기
+  function calculateMaxLimit(requestedBudgets, totalBudget) {
+    let minLimit = 0;
+    let maxLimit = Math.max(...requestedBudgets);
+    let bestLimit = 0;
+
+    while (minLimit <= maxLimit) {
+      const currentLimit = Math.floor((minLimit + maxLimit) / 2);
+      let budgetSum = 0;
+
+      for (let budget of requestedBudgets) {
+        budgetSum += budget > currentLimit ? currentLimit : budget;
+      }
+
+      if (budgetSum <= totalBudget) {
+        bestLimit = currentLimit;
+        minLimit = currentLimit + 1;
+      } else {
+        maxLimit = currentLimit - 1;
+      }
+    }
+
+    return bestLimit;
+  }
+
+  console.log(calculateMaxLimit(requestedBudgets, totalBudget));
+}


### PR DESCRIPTION
### 📘 문제 설명  
문제 링크 : [백준 2512번](https://www.acmicpc.net/problem/2512)

---

### 💡 풀이 요약  

- 총 요청 예산 합계가 총액 이하일 경우에는 요청 예산 중 최댓값을 출력
- 요청 합계가 초과하면 이진 탐색을 통해 조건을 만족하는 최대 상한액을 구합니다.
- 탐색 범위를 줄여가며 합산 예산과 총액을 비교하여 상한액을 조정합니다.

---

### 🤔 회고  

- 이진 탐색을 구현하면서 탐색 범위의 left, right 초기값을 고민했습니다.
- 탐색 조건을 만족할 때마다 상한액 후보를 갱신하고, 탐색 범위를 좁히는 방식으로 문제를 해결했습니다.
- 간단해 보이지만 입력 처리와 조건 분기(총합이 예산 이하일 때 바로 처리)도 고민하면서 구현했습니다.
