### PR TITLE
[BOJ 2583] 영역 구하기

### DIFF
--- a/이다은/week-3-2583.js
+++ b/이다은/week-3-2583.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const input = `5 7 3
+0 2 4 4
+1 1 2 5
+4 0 6 2`.trim().split('\n');
+// 디버깅을 위해 input값 수정, 백준에는 아래 코드 사용
+//const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+// 첫 줄
+const [M, N, K] = input[0].split(' ').map(Number);
+
+// 직사각형 좌표
+const rects = input.slice(1).map(line => line.split(' ').map(Number));
+
+// map 초기화
+const map = Array.from({ length: M }, () => Array(N).fill(0));
+
+for (let i = 0; i < K; i++) {
+  const [x1, y1, x2, y2] = rects[i];
+
+  for (let y = y1; y < y2; y++) {
+    for (let x = x1; x < x2; x++) {
+      map[y][x] = 1;  // 직사각형 부분을 1로 채움
+    }
+  }
+}
+//console.log(map);
+
+const directions = [
+  [0, 1],  
+  [1, 0],  
+  [0, -1],
+  [-1, 0] 
+];
+
+function bfs(startY, startX) {
+  let queue = [[startY, startX]];
+  map[startY][startX] = 1; // 현재 위치 queue에 넣고 방문 처리
+  let size = 1; 
+
+  while (queue.length) { //큐가 비어있을 때 까지 반복
+    const [y, x] = queue.shift(); //현재 위치 꺼내기
+
+    for (const [dy, dx] of directions) {
+      const ny = y + dy;
+      const nx = x + dx;
+
+      if ( //범위 조건 설정
+        ny >= 0 && ny < M &&
+        nx >= 0 && nx < N &&
+        map[ny][nx] === 0
+      ) {
+        map[ny][nx] = 1; // 방문 처리
+        queue.push([ny, nx]);
+        size++;
+      }
+    }
+  }
+
+  return size;
+}
+
+const areas = [];
+
+for (let y = 0; y < M; y++) {
+  for (let x = 0; x < N; x++) {
+    if (map[y][x] === 0) {
+      const areaSize = bfs(y, x);
+      areas.push(areaSize);
+    }
+  }
+}
+
+areas.sort((a, b) => a - b);
+console.log(areas.length);
+console.log(areas.join(' '));
+
+


### PR DESCRIPTION
### 📘 문제 설명  
문제 링크 : (https://www.acmicpc.net/problem/2583)
영역 구하기 (BOJ 2583)
M x N 크기의 모눈종이에 K개의 직사각형을 그려 채운 후, 남은 빈 영역(0)의 개수와 각 넓이를 하는 문제.

---

### 💡 풀이 요약  

- M x N 2차원 배열을 0으로 초기화한 뒤, K개의 직사각형 좌표를 순회하며 해당 구간을 1로 마킹하여 방문한 영역으로 표시.
- map을 전체 순회하면서 아직 방문하지 않은 0 위치를 만나면 BFS를 시작해 연결된 모든 0을 방문 처리하며 넓이를 계산.
- 넓이 계산은 size = 1부터 시작하고, 연결된 0을 탐색할 때마다 size++ 하여 누적.

---

### 🤔 회고  

- 문제에서의 (0,0)과 JS 배열에서의 [0][0]의 위치가 다르다는 점이 처음에 혼란스러워서 시간이 꽤 걸렸다. map[y][x]로 처리하면 좌표 변환 없이도 동작한다는 점을 디버깅을 통해 이해하게 되었다.
- map[y][x] = 1로 방문 처리를 해서 visited 배열 없이도 구현이 가능했다. BFS 문제의 기본기를 복습하기 좋은 문제였다.