### PR TITLE
[BOJ 1931] 회의실 배정

### DIFF
--- a/이다은/week-4-1931.js
+++ b/이다은/week-4-1931.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const input = `11
+1 4
+3 5
+0 6
+5 7
+3 8
+5 9
+6 10
+8 11
+8 12
+2 13
+12 14`.trim().split('\n');
+// 디버깅을 위해 input값 수정, 백준에는 아래 코드 사용
+//const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+// 1. 회의 리스트 만들기
+const N = Number(input[0]); // 회의 수
+const meetings = input.slice(1).map(line => {
+  const [start, end] = line.split(' ').map(Number);
+  return [start, end];
+});
+// 2. 회의 시간 정렬(끝나는 시간을 기준으로)
+meetings.sort((a, b) => {
+  if (a[1] === b[1]) {
+    return a[0] - b[0];// 끝나는 시간 같으면 시작 시간 빠른 순
+  }
+  return a[1] - b[1];// 끝나는 시간 빠른 순
+});
+
+//console.log(meetings); // 확인용
+
+// 3. 회의 개수 세기
+let count = 0; //선택한 회의 수
+let lastEndTime = 0; // 마지막으로 선택한 회의의 끝나는 시간
+
+for (const [start, end] of meetings) {
+  if (start >= lastEndTime) {
+    // 현재 회의의 시작 시간이 마지막으로 선택한 회의의 끝나는 시간보다 크거나 같으면
+    // 회의를 선택할 수 있음
+    count++;
+    lastEndTime = end;
+  }
+}
+
+console.log(count);


### PR DESCRIPTION
### 📘 문제 설명  

문제 링크 : (https://www.acmicpc.net/problem/1931)
하나의 회의실에 N개의 회의를 배정할 때, 회의 시간이 겹치지 않도록 하면서 사용할 수 있는 최대 회의 개수를 구하는 문제입니다.

---

### 💡 풀이 요약  

- 그리디 알고리즘을 사용하여 문제를 해결했습니다.
- meetings 배열을 끝나는 시간 기준으로 정렬하고, 끝나는 시간이 같을 경우 시작 시간 기준으로 정렬 -> 이전 회의의 종료 시간보다 시작 시간이 같거나 이후인 회의만 선택하여 count를 증가 -> 회의가 가능한 한 많이 열리도록 함

---

### 🤔 회고  

- 전형적인 그리디 문제였던 것 같습니다!
